### PR TITLE
Layout Rules v3

### DIFF
--- a/hyprland.conf
+++ b/hyprland.conf
@@ -82,12 +82,30 @@ misc {
    background_color = $background
 }
 
-layerrule = blur, walker
-layerrule = ignorezero, walker
-layerrule = blur, waybar
-layerrule = blur, notifications
-layerrule = blur, swayosd
-layerrule = ignorealpha 0.2, swayosd
-layerrule = ignorealpha 0.2, notifications
-layerrule = ignorealpha 0.2, waybar
-layerrule = ignorealpha 0.2, walker
+layerrule {
+  name = layerrule-1
+  blur = on
+  ignore_alpha = 0.2
+  match:namespace = walker
+}
+
+layerrule {
+  name = layerrule-2
+  blur = on
+  ignore_alpha = 0.2
+  match:namespace = waybar
+}
+
+layerrule {
+  name = layerrule-3
+  blur = on
+  ignore_alpha = 0.2
+  match:namespace = notifications
+}
+
+layerrule {
+  name = layerrule-4
+  blur = on
+  ignore_alpha = 0.2
+  match:namespace = swayosd
+}


### PR DESCRIPTION
Layout rules in hyprland.conf were converted to the v3 layer rules syntax using [hyprrulefix](https://itsohen.github.io/hyprrulefix/)